### PR TITLE
Added api route to display all the resorts in JSON

### DIFF
--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -150,6 +150,15 @@ function api(req, res, next) {
   });
 }
 
+function renderApiResorts(req, res, next) {
+  req.data.get(req.params.resort, function(err, resorts) {
+    if(err) {
+      return next(err);
+    }
+    res.send(resorts);
+  });
+}
+
 function routes(app) {
 
   function reqData(req, res, next) {
@@ -181,6 +190,7 @@ function routes(app) {
   app.get('/tag/:tag', reqData, tag, renderResorts);
   app.get('/stars', reqData, stars, renderResorts);
   app.get('/api/resort/:resort', reqData, api);
+  app.get('/api/resorts/', reqData, renderApiResorts);
   app.get('/sitemap.xml', reqData, sitemap);
   app.get('/about', about);
   app.get('/absent', reqData, absent, renderResorts);


### PR DESCRIPTION
Hi Damian,

I use liftie in my Snow2 app, but wanted to get the resorts directly from liftie.
That way, when someone adds resort, they will be available to Snow2 right away.
Because the json is about 139 KB now and I want to reduce the data usage (on mobile phone) I am thinking about just getting all the info once a day. Or maybe create some option for that.

Can you check my files?

Regards,

Paul